### PR TITLE
Fix all lint errors so colcon test now passes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_compile_options(-Wall -Wextra -Wpedantic)
 
 # Find the core interface library
 include(ExternalProject)
-ExternalProject_Add(libsurvive
+externalproject_add(libsurvive
   GIT_REPOSITORY https://github.com/cntools/libsurvive.git
   GIT_TAG master
   CMAKE_ARGS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+Any contribution that you make to this repository will
+be under the MIT license, as dictated by that
+[license](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Progress:
 - [x] test connect callback
 - [x] fix timestamp errors
 - [x] fix button callback (only works on Tracker 2.0 wirelessly via watchman)
+- [ ] add unit tests
 - [ ] fix composable node (not a functional blocker right now)
 - [ ] add linting checks (nice to have)
 - [ ] convert to lifecycle node (nice to have)
+- [ ] add circlce, mergify and dependebot integration
 
 # Installation instructions
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Progress:
 - [x] test connect callback
 - [x] fix timestamp errors
 - [x] fix button callback (only works on Tracker 2.0 wirelessly via watchman)
+- [x] add linting checks (nice to have)
 - [ ] add unit tests
 - [ ] fix composable node (not a functional blocker right now)
-- [ ] add linting checks (nice to have)
 - [ ] convert to lifecycle node (nice to have)
 - [ ] add circlce, mergify and dependebot integration
 
@@ -38,17 +38,25 @@ sudo udevadm control --reload-rules && udevadm trigger
 
 You can now choose to build the driver natively or in a container. The benefit of launching it within a container is that it won't interfere with any pre-existing ROS installation on your machine. However, you will need docker-ce and the compose plugin for things to work.
 
-## Containerized installation (easier)
+## Containerized build and test (easiest and recommended)
 
-Install docker: https://docs.docker.com/engine/install/ubuntu/
+Install docker and docker-compose: https://docs.docker.com/engine/install/ubuntu/
 
 ```sh
 $ docker compose build
+$ docker compose run libsurvive_ros2 colcon test
 ```
 
-This will checkout a lightweight ROS2 rolling container, augment it with a few system dependencies, checkout and build the code and drop you into a bash shell as user `ubuntu` at the home directory `~/ros2_ws/src`.
+This will checkout a lightweight ROS2 rolling container, augment it with a few system dependencies, checkout and build the code and drop you into a bash shell as user `ubuntu` at the home directory `~/ros2_ws/src`. If you'd rather build and test for ROS2 Foxy on arm64, as an example, you'd do this:
 
-## Native installation (more flexible)
+```sh
+$ docker compose build --build-arg ARCH=arm64 --build-arg ROS_DISTRO=foxy
+$ docker compose run libsurvive_ros2 colcon test  # optional, to test the package
+```
+
+Note that if you are building on a different architecture than the host you must follow the docker/QEMU installation instructions here before running the command above. Here is a link to a document outlining how this is done: https://docs.nvidia.com/datacenter/cloud-native/playground/x-arch.html
+
+## Native build and test (not recommended)
 
 You'll need ROS2 installed: https://docs.ros.org/en/humble/Installation.html
 
@@ -56,24 +64,28 @@ You'll also need to follow the instructions here:
 
 ```sh
 sudo apt-get install build-essential \
-    zlib1g-dev \
-    libx11-dev \
-    libusb-1.0-0-dev \
+    cmake \
     freeglut3-dev \
+    libatlas-base-dev \
     liblapacke-dev \
     libopenblas-dev \
-    libatlas-base-dev \
-    cmake
+    libpcap-dev \
+    libusb-1.0-0-dev \
+    libx11-dev \
+    zlib1g-dev
 ```
 
-Finally source ROS2, create a workspace, checkout, compile and source the code:
+Finally source ROS2, create a workspace, checkout, compile and test:
 
-```
+```sh
 $ mkdir ~/ros2_ws/src
 $ cd  ~/ros2_ws/src
 $ git clone https://github.com/asymingt/libsurvive_ros2.git
 $ cd ..
+$ rosdep update
+$ rosdep install --from-paths src --ignore-src -r -y
 $ colcon build
+$ colcon test  # optional, to test the package
 $ source install/setup.bash
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,4 @@ services:
       - /dev/bus/usb:/dev/bus/usb
     ports:
       - "9090:9090"
-    command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py rosbridge:=true
+    command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py rosbridge:=true composable:=true

--- a/include/libsurvive_ros2/component.hpp
+++ b/include/libsurvive_ros2/component.hpp
@@ -21,18 +21,26 @@
 #ifndef LIBSURVIVE_ROS2__COMPONENT_HPP_
 #define LIBSURVIVE_ROS2__COMPONENT_HPP_
 
+// Libsurvive libraries
+#define SURVIVE_ENABLE_FULL_API
+#include <os_generic.h>
+#include <libsurvive/survive.h>
+#include <libsurvive/survive_api.h>
+
+// ROS2 libraries
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
 // STL libraries
-#include <mutex>
 #include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
 // ROS2 core
 #include <rclcpp/rclcpp.hpp>
-
-// ROS2 libraries
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 
 // ROS2 messages
 #include <diagnostic_msgs/msg/key_value.hpp>
@@ -41,25 +49,20 @@
 #include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
-// Libsurvive libraries
-extern "C" {
-#define SURVIVE_ENABLE_FULL_API
-#include <os_generic.h>
-#include <libsurvive/survive.h>
-#include <libsurvive/survive_api.h>
-}
+namespace libsurvive_ros2
+{
 
-namespace libsurvive_ros2 {
-
-class Component : public rclcpp::Node {
+class Component : public rclcpp::Node
+{
 public:
   explicit Component(const rclcpp::NodeOptions & options);
   virtual ~Component();
-  rclcpp::Time get_ros_time(const std::string& str, FLT timecode);
-  void publish_imu(const sensor_msgs::msg::Imu& msg);
+  rclcpp::Time get_ros_time(const std::string & str, FLT timecode);
+  void publish_imu(const sensor_msgs::msg::Imu & msg);
+
 private:
   void work();
-  SurviveSimpleContext *actx_;
+  SurviveSimpleContext * actx_;
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_static_broadcaster_;
   rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_publisher_;

--- a/package.xml
+++ b/package.xml
@@ -20,13 +20,9 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   
+  <exec_depend>rosbridge_suite</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_black</test_depend>
-  <test_depend>ament_cmake_clang_format</test_depend>
-  <test_depend>ament_cmake_clang_tidy</test_depend>
-  <test_depend>ament_cmake_copyright</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -28,7 +28,8 @@
 #include <libsurvive_ros2/component.hpp>
 
 // Main entry point of application.
-int main(int argc, char * argv[]) {
+int main(int argc, char * argv[])
+{
   rclcpp::init(argc, argv);
   rclcpp::executors::SingleThreadedExecutor exec;
   exec.add_node(std::make_shared<libsurvive_ros2::Component>(rclcpp::NodeOptions{}));


### PR DESCRIPTION
There are currently no functional tests; there are only linter tests. This PR fixes lint errors, so they all pass.
```
docker compose run libsurvive_ros2 colcon test --packages-select libsurvive_ros2 \
                                                                                   --event-handlers console_direct+
...
100% tests passed, 0 tests failed out of 8

Label Time Summary:
copyright     =   0.17 sec*proc (1 test)
cppcheck      =   0.10 sec*proc (1 test)
cpplint       =   0.16 sec*proc (1 test)
flake8        =   0.15 sec*proc (1 test)
lint_cmake    =   0.09 sec*proc (1 test)
linter        =   1.16 sec*proc (8 tests)
pep257        =   0.13 sec*proc (1 test)
uncrustify    =   0.10 sec*proc (1 test)
xmllint       =   0.26 sec*proc (1 test)

Total Test time (real) =   1.17 sec
Finished <<< libsurvive_ros2 [1.20s]

Summary: 1 package finished [1.30s]
ubuntu@db630216635d:~/ros2_ws$ 
```