### PR TITLE
Try and fix a docker bug that was probably masked by the docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Andrew Symington
+# Copyright (c) 2023 Andrew Symington
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -66,7 +66,7 @@ RUN sudo apt-get update                                                         
 # Initialization
 RUN echo -e "#!/bin/bash \n\
 set -e\n\
-source /opt/ros/$ROS_DISTRO/setup.bash \n\
+source /home/ubuntu/ros2_ws/install/setup.bash \n\
 exec \$@" > /home/ubuntu/ros2_ws/entrypoint.sh
 RUN chmod 755 /home/ubuntu/ros2_ws/entrypoint.sh
 WORKDIR /home/ubuntu/ros2_ws

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,6 @@ services:
       - /dev/bus/usb:/dev/bus/usb
     ports:
       - "9090:9090"
-    command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py rosbridge:=true composable:=true
+    entrypoint: /home/ubuntu/ros2_ws/entrypoint.sh
+    working_dir: /home/ubuntu/ros2_ws
+    command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py rosbridge:=true composable:=false


### PR DESCRIPTION
Attempts to fix issue #3 . I had mistakenly sourced the wrong workspace, potentially leading to the package `libsurvive_ros2` not being found. I think this didn't present locally because `docker compose` used an earlier cached image that was working. I must have messed it up and neglected to do a full rebuild. 