### PR TITLE
Compile libsurvive in release mode to suppress asserts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,12 @@ jobs:
       - run:
           name: Install docker client
           command: |
-            sudo apt-get install ca-certificates curl gnupg lsb-release
+            sudo apt-get install ca-certificates curl gnupg lsb-release -y --no-install-recommends
             sudo mkdir -m 0755 -p /etc/apt/keyrings
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+            sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y --no-install-recommends
       - run:
           name: Build code 
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             sudo apt-get install ca-certificates curl gnupg lsb-release -y --no-install-recommends
             sudo mkdir -m 0755 -p /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/docker.gpg > /dev/null
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update
             sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y --no-install-recommends

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ externalproject_add(libsurvive
   GIT_TAG master
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libsurvive-install
+    -DCMAKE_BUILD_TYPE=Release
 )
 
 # Find dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends                
         build-essential                                                         \
         cmake                                                                   \
         freeglut3-dev                                                           \
+        gdb                                                                     \
         libatlas-base-dev                                                       \
         liblapacke-dev                                                          \
         libopenblas-dev                                                         \
@@ -39,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends                
         libusb-1.0-0-dev                                                        \
         libx11-dev                                                              \
         sudo                                                                    \
+        valgrind                                                                \
         zlib1g-dev                                                              \
     && sudo rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,14 +21,17 @@
 # SOFTWARE.
 
 # Docker Compose Spec Version
-version: '3'
+# See: https://docs.docker.com/compose/compose-file/compose-versioning/#version-3
+version: '3.6'
 
 services:
   libsurvive_ros2:
     privileged: false
-    build: .
+    device_cgroup_rules:
+      - 'c *:* rmw'
     volumes:
-      - /dev/bus/usb:/dev/bus/usb
+      - /dev:/dev
+    build: .
     ports:
       - "9090:9090"
     entrypoint: /home/ubuntu/ros2_ws/entrypoint.sh


### PR DESCRIPTION
It seems like there are some aggressive asserts in `libsurvive` which end up sporadically halting the driver application from running. To avoid these, compile `libsurvive` in `Release` mode. Also, add `gdb` and `valgrind` to the docker image to facilitate easier debugging, and fix the `/dev` cgroup permissions to prevent having to run in privileged mode -- we really shouldn't need this for a simple tracking app.  