### PR TITLE
Build patch to fix wierd problem in ExternalProject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include(ExternalProject)
 externalproject_add(libsurvive
   GIT_REPOSITORY https://github.com/cntools/libsurvive.git
   GIT_TAG master
+  PATCH_COMMAND echo "sed -i 's/, tan$/, tan, Abs/' src/generated/common_math.py" \> patch && bash patch
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libsurvive-install
     -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Abs isn't imported by common_math.py in the ExternalProject libsurvive

It looks like my setup doesn't recognize the existing gen.h files and tries but fails to build them because kalman_kinematics.py doesn't have access to Abs from cnkalman.codegen