### PR TITLE
[bugfix] fix CI pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends                
         cmake                                                                   \
         freeglut3-dev                                                           \
         gdb                                                                     \
-        libatlas-base-dev                                                       \
         liblapacke-dev                                                          \
         libopenblas-dev                                                         \
         libpcap-dev                                                             \
@@ -45,7 +44,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends                
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Add an 'ubuntu' user with dialout/plugdev access and can use sudo passwordless.
-RUN useradd -ms /bin/bash ubuntu && echo "ubuntu:ubuntu" | chpasswd
 RUN usermod -aG sudo,dialout,plugdev ubuntu
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023 Andrew Symington
+# Copyright (c) 2025 Andrew Symington
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,20 +43,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends                
         zlib1g-dev                                                              \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Add an 'ubuntu' user with dialout/plugdev access and can use sudo passwordless.
-RUN usermod -aG sudo,dialout,plugdev ubuntu
+# Add an 'ros' user with dialout/plugdev access and can use sudo passwordless.
+RUN useradd -ms /bin/bash ros && echo "ros:ros" | chpasswd
+RUN usermod -aG sudo,dialout,plugdev ros
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Switch to the non-root user.
-USER ubuntu
+USER ros
 
 # Copy the source code into our test workspace.
-RUN mkdir -p /home/ubuntu/ros2_ws/src/libsurvive_ros2
-COPY --chown=ubuntu:ubuntu . /home/ubuntu/ros2_ws/src/libsurvive_ros2
+RUN mkdir -p /home/ros/ros2_ws/src/libsurvive_ros2
+COPY --chown=ros:ros . /home/ros/ros2_ws/src/libsurvive_ros2
 
 # Install baseline tools
 RUN sudo apt-get update                                                         \
-    && cd /home/ubuntu/ros2_ws                                                  \
+    && cd /home/ros/ros2_ws                                                     \
     && rosdep update                                                            \
     && rosdep install --from-paths src --ignore-src -r -y                       \
     && source /opt/ros/$ROS_DISTRO/setup.bash                                   \
@@ -66,9 +67,9 @@ RUN sudo apt-get update                                                         
 # Initialization
 RUN echo -e "#!/bin/bash \n\
 set -e\n\
-source /home/ubuntu/ros2_ws/install/setup.bash \n\
-exec \$@" > /home/ubuntu/ros2_ws/entrypoint.sh
-RUN chmod 755 /home/ubuntu/ros2_ws/entrypoint.sh
-WORKDIR /home/ubuntu/ros2_ws
-ENTRYPOINT [ "/home/ubuntu/ros2_ws/entrypoint.sh" ]
+source /home/ros/ros2_ws/install/setup.bash \n\
+exec \$@" > /home/ros/ros2_ws/entrypoint.sh
+RUN chmod 755 /home/ros/ros2_ws/entrypoint.sh
+WORKDIR /home/ros/ros2_ws
+ENTRYPOINT [ "/home/ros/ros2_ws/entrypoint.sh" ]
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ docker compose build
 $ docker compose run libsurvive_ros2 colcon test
 ```
 
-This will checkout a lightweight ROS2 rolling container, augment it with a few system dependencies, checkout and build the code and drop you into a bash shell as user `ubuntu` at the home directory `~/ros2_ws/src`. If you'd rather build and test for ROS2 Foxy on arm64, as an example, you'd do this:
+This will checkout a lightweight ROS2 rolling container, augment it with a few system dependencies, checkout and build the code and drop you into a bash shell as user `ros` at the home directory `/home/ros/ros2_ws/src`. If you'd rather build and test for ROS2 Foxy on arm64, as an example, you'd do this:
 
 ```sh
 $ docker compose build --build-arg ARCH=arm64 --build-arg ROS_DISTRO=foxy
@@ -68,7 +68,6 @@ You'll also need to follow the instructions here:
 sudo apt-get install build-essential \
     cmake \
     freeglut3-dev \
-    libatlas-base-dev \
     liblapacke-dev \
     libopenblas-dev \
     libpcap-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Andrew Symington
+# Copyright (c) 2025 Andrew Symington
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,6 @@ services:
     build: .
     ports:
       - "9090:9090"
-    entrypoint: /home/ubuntu/ros2_ws/entrypoint.sh
-    working_dir: /home/ubuntu/ros2_ws
+    entrypoint: /home/ros/ros2_ws/entrypoint.sh
+    working_dir: /home/ros/ros2_ws
     command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py rosbridge:=true composable:=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@
 
 # Docker Compose Spec Version
 # See: https://docs.docker.com/compose/compose-file/compose-versioning/#version-3
-version: '3.6'
 
 services:
   libsurvive_ros2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,6 @@
 
 services:
   libsurvive_ros2:
-    privileged: false
-    device_cgroup_rules:
-      - 'c *:* rmw'
-    volumes:
-      - /dev:/dev
     build: .
     ports:
       - "9090:9090"

--- a/launch/libsurvive_ros2.launch.py
+++ b/launch/libsurvive_ros2.launch.py
@@ -24,14 +24,14 @@ from ament_index_python.packages import get_package_share_directory
 
 import launch
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, DeclareLaunchArgument
-from launch_ros.descriptions import ComposableNode
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
 from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration
-from launch_ros.actions import Node, ComposableNodeContainer
+from launch_ros.actions import ComposableNodeContainer, Node
+from launch_ros.descriptions import ComposableNode
 
 # Bag to save data
-BAG_FILE = os.path.join(launch.logging.launch_config.log_dir, "libsurvive.bag")
+BAG_FILE = os.path.join(launch.logging.launch_config.log_dir, 'libsurvive.bag')
 
 # Default libsurvive configuration file
 CFG_FILE = os.path.join(
@@ -96,7 +96,7 @@ def generate_launch_description():
         name='rosbridge_server_node',
         condition=IfCondition(LaunchConfiguration('rosbridge')),
         parameters=[
-            {"port": 9090},
+            {'port': 9090},
         ],
         output='log')
     rosapi_node = Node(


### PR DESCRIPTION
Couple  of changes to make CI pipeline green again:

- Change python module import ordering and `"` -> `'` to satisfy flake8.
- Remove docker-compose version and set to privileged / default mode.
- Remove `libatlas-base-dev` as a dependency, because `liblapacke-dev` pulls in the right version.
- Switch docker image from user `ubuntu` to user `ros` because there is an inconsistency in the existence of user `ubuntu` between jazzy, humble and iron (doesn't exist) and rolling (does exist).