### PR TITLE
Add foxglove web bridge as an alternative to the ros bridge

### DIFF
--- a/.devcontainer/foxy/devcontainer.json
+++ b/.devcontainer/foxy/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/.devcontainer/galactic/devcontainer.json
+++ b/.devcontainer/galactic/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/.devcontainer/humble/devcontainer.json
+++ b/.devcontainer/humble/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/.devcontainer/iron/devcontainer.json
+++ b/.devcontainer/iron/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/.devcontainer/jazzy/devcontainer.json
+++ b/.devcontainer/jazzy/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/.devcontainer/kilted/devcontainer.json
+++ b/.devcontainer/kilted/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/.devcontainer/rolling/devcontainer.json
+++ b/.devcontainer/rolling/devcontainer.json
@@ -41,7 +41,7 @@
     ],
     "remoteUser": "ros", 
     "containerUser": "ros",
-    "forwardPorts": [8765],
+    "forwardPorts": [8765, 9090],
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros/ros2_ws/src/libsurvive_ros2,type=bind",
     "workspaceFolder": "/home/ros/ros2_ws"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ add_compile_options(-Wall -Wextra -Wpedantic)
 include(ExternalProject)
 externalproject_add(libsurvive
   GIT_REPOSITORY https://github.com/cntools/libsurvive.git
-  GIT_TAG master
+  GIT_TAG 32cf62c52744fdc32003ef8169e8b81f6f31526b
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libsurvive-install
     -DCMAKE_BUILD_TYPE=Release

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ There are three launch arguments to `libsurvive_ros2.launch.py` to help get up a
 
 - `namespace = string (default: 'libsurvive')` : This is the namespace on which to add the extra topics for sensor data.
 - `record = boolean (default: false)` : Start a `ros2 bag record` to save `/tf` and `/tf_static` topics to a ros bag in the ROS2 log directory for the current launch ID as `libsurvive.bag`.
-- `rosbridge = boolean (default: false)` : Starts a `rosbridge_server` and `rosapi`, which offers data over a websocket by default at port 9090, which allows you to stream directly into the [foxglove.dev](https://foxglove.dev) robotics visualization tool.
+- `foxbridge = boolean (default: false)` : Starts a `foxglove_bridge` to push data over a websocket at point 8765 (high performance).
+- `rosbridge = boolean (default: false)` : Starts a `rosbridge_server` and `rosapi` node to push data over a websocket at 9090 (more flexible).
 - `composable = boolean (default: false)`: For advanced users only -- it shows how to load the component-based version of the code to get zero-copy IPC between it and other composable nodes. 
 
 # Example visualization with Foxglove

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,8 @@ services:
   libsurvive_ros2:
     build: .
     ports:
-      - "9090:9090"
+      - 8765
+      - 9090
     entrypoint: /home/ros/ros2_ws/entrypoint.sh
     working_dir: /home/ros/ros2_ws
-    command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py rosbridge:=true composable:=false
+    command: ros2 launch libsurvive_ros2 libsurvive_ros2.launch.py foxbridge:=true composable:=false

--- a/launch/libsurvive_ros2.launch.py
+++ b/launch/libsurvive_ros2.launch.py
@@ -56,6 +56,8 @@ def generate_launch_description():
                               description='Launch in a composable container'),
         DeclareLaunchArgument('rosbridge', default_value='false',
                               description='Launch a rosbridge'),
+        DeclareLaunchArgument('foxbridge', default_value='false',
+                              description='Launch a foxglove bridge'),
         DeclareLaunchArgument('record', default_value='false',
                               description='Record data with rosbag')]
 
@@ -89,7 +91,7 @@ def generate_launch_description():
         ],
         output='log')
 
-    # For bridging connection to foxglove running on a remote server.
+    # For ros webdocker bridge
     rosbridge_node = Node(
         package='rosbridge_server',
         executable='rosbridge_websocket',
@@ -106,6 +108,17 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('rosbridge')),
         output='log')
 
+    # For foxglove websocket bridge
+    foxbridge_node = Node(
+        package="foxglove_bridge",
+        executable="foxglove_bridge",
+        name="foxglove_bridge",
+        condition=IfCondition(LaunchConfiguration('foxbridge')),
+        parameters=[
+            {'port': 8765},
+        ],
+        output='log')
+
     # For recording all data from the experiment
     bag_record_node = ExecuteProcess(
         cmd=['ros2', 'bag', 'record', '-o', BAG_FILE] + [
@@ -119,6 +132,7 @@ def generate_launch_description():
         arguments + [
             libsurvive_node,
             libsurvive_composable_node,
+            foxbridge_node,
             rosbridge_node,
             rosapi_node,
             bag_record_node

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>tf2_ros</depend>
   
   <exec_depend>rosbridge_suite</exec_depend>
+  <exec_depend>foxglove_bridge</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
I have found the foxglove web bridge to work very well with the foxglove studio observability tool. This PR adds support for the foxglove bridge and changes the instructions to use it by default.